### PR TITLE
use 'oneDayTotalFee' for sorting by fee

### DIFF
--- a/src/components/PairList/index.js
+++ b/src/components/PairList/index.js
@@ -131,7 +131,7 @@ const FIELD_TO_VALUE = {
   [SORT_FIELD.VOL]: 'oneDayVolumeUSD',
   [SORT_FIELD.TXNS]: 'oneDayTxns',
   [SORT_FIELD.VOL_7DAYS]: 'oneWeekVolumeUSD',
-  [SORT_FIELD.FEES]: 'oneDayExtraFee'
+  [SORT_FIELD.FEES]: 'oneDayTotalFee'
 }
 
 


### PR DESCRIPTION
Currently  mooniswap-info presents fee + slippage in details, but sorts by fee which results in confusing user experience 